### PR TITLE
Add official custom GPT documentation index and refresh guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Custom GPT Wizard (CGW) - Knowledge Repository Changelog
 
+## Unreleased (October 2025)
+
+### Added
+- **Official Custom GPT Documentation Index** summarizing the current OpenAI help center and platform references for building, managing, and publishing GPTs.
+
+### Changed
+- README and wiki updated with quick-start guidance that points to the refreshed official resources so CGW users stay aligned with the modern ChatGPT builder and GPT Store requirements.
 
 
 ## Version 0.0.42 December 14, 2023

--- a/Knowledge/Instructions/official_gpt_resources_2025.md
+++ b/Knowledge/Instructions/official_gpt_resources_2025.md
@@ -1,0 +1,24 @@
+# Official Custom GPT Documentation Index (October 2025 refresh)
+
+This index consolidates the most up-to-date official help center and platform documentation from OpenAI about creating, managing, and publishing custom GPTs. It is intended to supplement CGW's guidance so builders can jump straight to authoritative instructions when they need deeper detail or policy clarifications.
+
+> **Note:** All of the articles below live inside OpenAI's dedicated [GPTs help center collection](https://help.openai.com/en/collections/9139824-gpts). Individual article slugs are provided for quick access.
+
+| Topic | Official resource | Key takeaways for builders | How CGW users can apply it |
+| --- | --- | --- | --- |
+| Getting started | [Create a GPT](https://help.openai.com/en/articles/8820655-create-a-gpt) | Walks through the updated builder interface, including how instructions, Knowledge files, conversation starters, and capability toggles (web browsing, DALL·E, code interpreter) now appear in the side-by-side preview experience. | Pair this with CGW's EGBA walkthroughs to mirror the official builder flow and verify nothing in the UI has changed before sharing directions with teammates or clients. |
+| Day-to-day management | [Manage GPTs](https://help.openai.com/en/articles/8820614-manage-gpts) | Covers renaming, duplicating, archiving, setting default capabilities, and controlling whether a GPT is visible only to you, shared by link, or listed publicly. | Use these controls to keep draft GPTs private until they are ready for user testing, and document the lifecycle inside CGW's project notes. |
+| Privacy and data controls | [Custom GPT privacy controls](https://help.openai.com/en/articles/8595947-custom-gpt-privacy-controls) | Explains the "Allow my GPT to be used for model improvement" toggle, data retention behavior, and how Knowledge files are stored. | Aligns with CGW's emphasis on ethical builds—reference this when advising on compliance or responding to user privacy questions. |
+| GPT Store overview | [GPT Store overview](https://help.openai.com/en/articles/8939316-gpt-store-overview) | Details eligibility (Plus/Team/Enterprise), quality and policy review, how rankings work, and the new revenue share metrics dashboard. | Reference before you encourage someone to publish via CGW so they can prepare assets, confirm policy alignment, and understand discovery mechanics. |
+| Builder profile | [Set up your builder profile](https://help.openai.com/en/articles/8939335-set-up-your-builder-profile) | Explains display name, profile handle, tagline, and external links required for public listings plus how verification works. | Include these requirements in CGW project kickoff checklists so marketing assets are ready before submission. |
+| Publishing workflow | [Publish or share a GPT](https://help.openai.com/en/articles/8820616-publish-or-share-a-gpt) | Step-by-step instructions for sharing via direct link, publishing to the store, and updating version notes. | Sync this with CGW's slash commands (/MAKE, /BUILD) to outline next steps once a configuration is approved. |
+| GPT actions | [GPT actions quickstart](https://platform.openai.com/docs/guides/gpt-actions) | Provides the modern schema format, authentication models (API key, OAuth), testing inside the builder, and deployment safeguards. | When CGW suggests adding actions, crosslink to this quickstart so developers can wire up external tools confidently. |
+| Analytics | [GPT analytics dashboard](https://help.openai.com/en/articles/8940147-gpt-analytics-dashboard) | Describes engagement metrics (opens, conversations, saves), trending tabs, and filters for time ranges. | Use analytics data to inform CGW-led iteration cycles and highlight measurable outcomes to stakeholders. |
+| Policy compliance | [GPT policy and review guidelines](https://help.openai.com/en/articles/8859858-gpt-policy-and-review-guidelines) | Summarizes restricted content, intellectual property expectations, and enforcement steps reviewers take before a GPT appears in the store. | Reference this whenever CGW warns about sensitive content so builders can remediate issues before submission. |
+
+## How to keep this index current
+
+1. Revisit the GPTs collection link at least once per release cycle—OpenAI adds new articles as capabilities expand (e.g., workspace analytics, fine-grained access controls).
+2. Compare article timestamps with CGW's change log; add new rows or update summaries when OpenAI revises the builder UI.
+3. If an article is deprecated, move it to an "Archive" subsection and note the replacement resource so historical instructions remain traceable.
+4. Encourage contributors to open issues or PRs whenever they notice help center updates during their own GPT building work.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,19 @@ For more detailed comparisons or assistance, visit [CGW's Knowledge Repository](
 2. **Contribution**: Users are encouraged to contribute their own insights, configurations, or solutions to enrich the CGW knowledge base.
 3. **Feedback**: Share your experiences and suggestions to improve CGW.
 
+## Official OpenAI Custom GPT resources (2025 refresh)
+
+OpenAI has published a refreshed suite of help center and platform documentation that complements CGW's advice. Start with the new [Official Custom GPT Documentation Index](Knowledge/Instructions/official_gpt_resources_2025.md) for quick links and context. Highlights include:
+
+- **Create a GPT** – an authoritative walkthrough of the latest builder UI, covering instructions, Knowledge files, conversation starters, and capability toggles for browsing, DALL·E 3, and code interpreter.
+- **Manage GPTs** – guidance for renaming, duplicating, archiving, and controlling share settings so drafts stay private until you're ready to publish.
+- **Custom GPT privacy controls** – details about conversation retention, the "Allow my GPT to be used for model improvement" toggle, and how uploaded Knowledge files are handled.
+- **GPT Store overview & Builder profile** – publication requirements, quality review criteria, builder profile fields, and how discovery and revenue share now operate.
+- **GPT actions quickstart** – updated schema and authentication patterns for connecting external tools via Actions.
+- **GPT analytics dashboard** – metrics definitions that make it easier to iterate on your builds using real engagement data.
+
+Referencing these official docs alongside CGW ensures the wizard's recommendations stay aligned with the most recent changes on chatgpt.com, including GPT Store publishing rules and builder profile verification steps.
+
 ## Contributing
 
 We welcome contributions from the community. Please follow these steps to contribute:

--- a/faq_and_wiki/faq_wiki.md
+++ b/faq_and_wiki/faq_wiki.md
@@ -78,21 +78,40 @@ Future developments for CGW include more advanced customization options, broader
 ---
 
 ## Quick Start Guide
-[To be expanded]
+1. **Review the official builder flow** – Skim the [Create a GPT](../Knowledge/Instructions/official_gpt_resources_2025.md) summary so you know where instructions, Knowledge files, and capability toggles now live in the ChatGPT interface before you open CGW.
+2. **Launch CGW and trigger `/MAKE`** – Let EGBA capture your goals, user personas, and compliance needs. Keep the Manage GPTs article from the documentation index handy in case you need to duplicate or archive drafts mid-process.
+3. **Upload supporting Knowledge** – Follow OpenAI’s privacy guidance (outlined in the documentation index) when attaching PDFs, spreadsheets, or FAQs so sensitive data remains opt-in and well scoped.
+4. **Decide on capabilities** – Use the updated builder UI to toggle browsing, DALL·E, and code interpreter features exactly as CGW’s plan recommends.
+5. **Wire up Actions (optional)** – When CGW suggests external integrations, reference the GPT Actions quickstart to author and validate the OpenAPI schema.
+6. **Share safely** – Use the publish/share article highlighted in the documentation index to decide whether to keep the GPT private, share a preview link, or submit to the GPT Store once you have marketing assets ready.
 
 [Back to Top](#table-of-contents)
 
 ---
 
 ## Detailed How-To
-[To be expanded]
+### Building with CGW and the official docs side-by-side
+
+1. **Define objectives with CGW** – Start a `/BUILD` session and capture success metrics that you will later monitor in the GPT analytics dashboard.
+2. **Draft instructions** – Translate CGW’s structured plan into the builder’s Instructions pane, ensuring tone, guardrails, and escalation paths match policy requirements.
+3. **Attach Knowledge responsibly** – Label each file clearly, cite owners, and align retention decisions with the privacy controls article.
+4. **Configure Actions** – Use the GPT Actions quickstart to declare authentication, endpoints, and user-facing descriptions; test within the builder until CGW confirms success cases.
+5. **Set up the builder profile** – Prepare your display name, handle, tagline, and external links before submitting to the GPT Store to avoid review delays.
+6. **Run dry runs** – Share the GPT privately, collect feedback, and archive unused iterations using the Manage GPTs guidance.
+7. **Publish and monitor** – Once approved, publish to the store, write clear release notes, and monitor engagement via GPT analytics for next-round improvements.
 
 [Back to Top](#table-of-contents)
 
 ---
 
 ## Troubleshooting
-[To be expanded]
+| Issue | What to check | Helpful official reference |
+| --- | --- | --- |
+| Builder UI looks different from CGW screenshots | Confirm whether OpenAI recently updated the interface and reread the Create a GPT article for layout changes. | [Create a GPT](../Knowledge/Instructions/official_gpt_resources_2025.md) |
+| Knowledge files are not loading | Verify file formats and sizes against OpenAI’s limits; reupload after trimming sensitive data. | Custom GPT privacy controls (see documentation index) |
+| Actions failing authentication | Double-check the schema and OAuth/API key configuration against the GPT Actions quickstart, then retest in the builder. | GPT actions quickstart |
+| GPT rejected from the store | Review the policy and review guidelines plus builder profile requirements before resubmitting. | GPT Store overview, Builder profile, GPT policy and review guidelines |
+| Analytics missing data | Allow up to 24 hours for metrics to populate and confirm the GPT is published or shared broadly enough to collect engagement. | GPT analytics dashboard |
 
 [Back to Top](#table-of-contents)
 
@@ -120,7 +139,9 @@ Future developments for CGW include more advanced customization options, broader
 ---
 
 ## References
-[To be expanded]
+- [Official Custom GPT Documentation Index (2025 refresh)](../Knowledge/Instructions/official_gpt_resources_2025.md)
+- OpenAI GPTs help center collection (see index above for direct article links)
+- CGW Enhanced GPT Builder Assistant (EGBA) instructions within this repository
 
 [Back to Top](#table-of-contents)
 


### PR DESCRIPTION
## Summary
- add a 2025 refresh index that links to OpenAI’s latest official custom GPT documentation
- update the README and wiki quick-start/troubleshooting sections to reference the new resources
- record the documentation refresh in the changelog

## Testing
- not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68e2f96039a48331b9efd5329a3c7ea6